### PR TITLE
Add .editorconfig + .gitattributes to force consistent line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*]
+end_of_line = lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
## Description
Having mixed groups of windows and unix users creates confusion when line ending errors occur (Happened in the last 3 groups I have TA'd).
The solution would be to add an .editorconfig and a .gitattributes file

.gitattributes - Tells git to auto-convert and text files to LF line endings on commit
.editorconfig - Tells vscode (and other editors) to use LF line endings as default
